### PR TITLE
Better str representation

### DIFF
--- a/python/stringalign/evaluation.py
+++ b/python/stringalign/evaluation.py
@@ -169,8 +169,10 @@ class LineError:
             tokenizer=tokenizer,
         )
 
-    def __str__(self) -> str:
+    def __repr__(self) -> str:
         return f"LineError('{self.reference}', '{self.predicted}', metadata={self.metadata})"
+
+    __str__ = __repr__
 
 
 @dataclass(frozen=True, slots=True)
@@ -255,5 +257,7 @@ class TranscriptionEvaluator:
     def __len__(self) -> int:
         return len(self.line_errors)
 
-    def __str__(self) -> str:
+    def __repr__(self) -> str:
         return f"TranscriptionEvaluator(len={len(self)})"
+
+    __str__ = __repr__

--- a/python/stringalign/evaluation.py
+++ b/python/stringalign/evaluation.py
@@ -251,3 +251,9 @@ class TranscriptionEvaluator:
             predictions=predictions,
             line_errors=line_errors,
         )
+
+    def __len__(self) -> int:
+        return len(self.line_errors)
+
+    def __str__(self) -> str:
+        return f"TranscriptionEvaluator(len={len(self)})"


### PR DESCRIPTION
Closes #20 

Changed `__str__` to `__repr__` to prevent stringalign from freezing Jupyter notebooks as well