### PR TITLE
Add token error rate to confusion matrix

### DIFF
--- a/pdm.lock
+++ b/pdm.lock
@@ -5,7 +5,7 @@
 groups = ["default", "dev"]
 strategy = ["cross_platform", "inherit_metadata"]
 lock_version = "4.5.0"
-content_hash = "sha256:39054763afc8703500940e45f2a316453247d6150da452da4ba3f970bb85c262"
+content_hash = "sha256:76bee376bc2c09fed09ea64efffc1e0b64d67806f60a5af65393c3b2ca73541e"
 
 [[metadata.targets]]
 requires_python = ">=3.11"
@@ -39,12 +39,26 @@ files = [
 ]
 
 [[package]]
+name = "click"
+version = "8.2.1"
+requires_python = ">=3.10"
+summary = "Composable command line interface toolkit"
+groups = ["dev"]
+dependencies = [
+    "colorama; platform_system == \"Windows\"",
+]
+files = [
+    {file = "click-8.2.1-py3-none-any.whl", hash = "sha256:61a3265b914e850b85317d0b3109c7f8cd35a670f963866005d6ef1d5175a12b"},
+    {file = "click-8.2.1.tar.gz", hash = "sha256:27c491cc05d968d271d5a1db13e3b5a184636d9d930f148c50b038f0d0646202"},
+]
+
+[[package]]
 name = "colorama"
 version = "0.4.6"
 requires_python = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,!=3.6.*,>=2.7"
 summary = "Cross-platform colored terminal text."
 groups = ["dev"]
-marker = "sys_platform == \"win32\""
+marker = "sys_platform == \"win32\" or platform_system == \"Windows\""
 files = [
     {file = "colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6"},
     {file = "colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44"},
@@ -240,6 +254,21 @@ dependencies = [
 files = [
     {file = "jedi-0.19.1-py2.py3-none-any.whl", hash = "sha256:e983c654fe5c02867aef4cdfce5a2fbb4a50adc0af145f70504238f18ef5e7e0"},
     {file = "jedi-0.19.1.tar.gz", hash = "sha256:cf0496f3651bc65d7174ac1b7d043eff454892c708a87d1b683e57b569927ffd"},
+]
+
+[[package]]
+name = "jiwer"
+version = "3.1.0"
+requires_python = ">=3.8"
+summary = "Evaluate your speech-to-text system with similarity measures such as word error rate (WER)"
+groups = ["dev"]
+dependencies = [
+    "click>=8.1.8",
+    "rapidfuzz>=3.9.7",
+]
+files = [
+    {file = "jiwer-3.1.0-py3-none-any.whl", hash = "sha256:5a14b5bba4692e1946ca3c6946435f7d90b1b526076ccb6c12be763e2146237d"},
+    {file = "jiwer-3.1.0.tar.gz", hash = "sha256:dc492d09e570f1baba98c76aba09baf8e09c06e6808a4ba412dd4bde67fb79ac"},
 ]
 
 [[package]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,17 +27,6 @@ module-name = "stringalign._stringutils"
 [tool.pdm]
 distribution = true
 
-[tool.pdm.dev-dependencies]
-dev = [
-    "ruff>=0.6.7",
-    "pytest>=8.3.3",
-    "hypothesis>=6.112.1",
-    "pytest-cov>=5.0.0",
-    "ipython>=8.27.0",
-    "Levenshtein>=0.26.0",
-    "mypy>=1.13.0",
-]
-
 [tool.ruff]
 line-length = 120
 
@@ -65,3 +54,15 @@ tag_message = "Bump version: {current_version} → {new_version}"
 
 [[tool.bumpversion.files]]
 filename = "Cargo.toml"
+
+[dependency-groups]
+dev = [
+    "ruff>=0.6.7",
+    "pytest>=8.3.3",
+    "hypothesis>=6.112.1",
+    "pytest-cov>=5.0.0",
+    "ipython>=8.27.0",
+    "Levenshtein>=0.26.0",
+    "mypy>=1.13.0",
+    "jiwer>=3.1.0",
+]

--- a/python/stringalign/statistics.py
+++ b/python/stringalign/statistics.py
@@ -151,6 +151,20 @@ class StringConfusionMatrix:
 
     compute_dice = compute_f1_score
 
+    def compute_token_error_rate(self) -> float:
+        """The number of token edits divided by the total number of tokens.
+
+        If the tokenizer tokenizes the string into characters, this is equivalent to
+        the character error rate (CER).
+        """
+        total_tokens = sum(self.true_positives.values()) + sum(self.false_negatives.values())
+        total_edit_counts = sum(self.edit_counts.values())
+        if total_edit_counts == 0 and total_tokens == 0:
+            return 0.0
+        elif total_tokens == 0:
+            return float("inf")
+        return total_edit_counts / total_tokens
+
     def __add__(self, other: Self) -> Self:
         if not isinstance(other, self.__class__):
             return NotImplemented

--- a/python/stringalign/tokenize.py
+++ b/python/stringalign/tokenize.py
@@ -44,8 +44,10 @@ class StringNormalizer:
         self.remove_non_word_characters = remove_non_word_characters
 
     def __call__(self, text: str) -> str:
+        # According to Unicode, we should normalize strings before casefolding them.
         if self.normalization is not None:
             text = unicodedata.normalize(self.normalization, text)
+
         if self.case_insensitive:
             text = text.casefold()
         if self.normalize_whitespace:
@@ -54,6 +56,11 @@ class StringNormalizer:
             text = re.sub(r"\s", "", text)
         if self.remove_non_word_characters:
             text = re.sub(r"[^\w\s]|_", "", text)
+
+        # Some of these operations, like casefolding, can make normalized text unnormalized.
+        # So we normalize again to ensure the text is in the correct form.
+        if self.normalization is not None:
+            text = unicodedata.normalize(self.normalization, text)
 
         return text
 

--- a/tests/statistics/ConfusionMatrix/test_compute_token_error_rate.py
+++ b/tests/statistics/ConfusionMatrix/test_compute_token_error_rate.py
@@ -24,6 +24,20 @@ def test_different_than_jiwer_on_decomposed_diacritic() -> None:
     assert ter > jiwer.cer(truth, predicted) - 1e-8
 
 
+def test_empty_reference_string_and_empty_predicted_string() -> None:
+    """The token error rate is zero for empty strings."""
+    cm = StringConfusionMatrix.from_strings("", "")
+    ter = cm.compute_token_error_rate()
+    assert ter == 0.0
+
+
+def test_empty_reference_string_and_non_empty_predicted_string() -> None:
+    """The token error rate is one for an empty reference string and a non-empty predicted string."""
+    cm = StringConfusionMatrix.from_strings("", "not empty")
+    ter = cm.compute_token_error_rate()
+    assert ter == float("inf")
+
+
 @hypothesis.given(
     predicted=st.text(alphabet=st.characters(max_codepoint=127)),  # ASCII characters only
     reference=st.text(alphabet=st.characters(max_codepoint=127), min_size=1),  # ASCII characters only

--- a/tests/statistics/ConfusionMatrix/test_compute_token_error_rate.py
+++ b/tests/statistics/ConfusionMatrix/test_compute_token_error_rate.py
@@ -1,0 +1,70 @@
+import unicodedata
+
+import hypothesis
+import hypothesis.strategies as st
+import jiwer
+import pytest
+from stringalign.statistics import StringConfusionMatrix
+
+
+def test_simple_example() -> None:
+    """The token error rate is the same as Jiwer's for a simple example."""
+    truth, predicted = "aaaabbcce", "aaabbbcda"
+    cm = StringConfusionMatrix.from_strings(truth, predicted)
+    ter = cm.compute_token_error_rate()
+    assert ter == pytest.approx(jiwer.cer(truth, predicted))
+
+
+def test_different_than_jiwer_on_decomposed_diacritic() -> None:
+    """The token error rate is different compared to Jiwer for decomposed diacritic characters."""
+    truth = unicodedata.normalize("NFD", "å")
+    predicted = "a"
+    cm = StringConfusionMatrix.from_strings(truth, predicted)
+    ter = cm.compute_token_error_rate()
+    assert ter > jiwer.cer(truth, predicted) - 1e-8
+
+
+@hypothesis.given(
+    predicted=st.text(alphabet=st.characters(max_codepoint=127)),  # ASCII characters only
+    reference=st.text(alphabet=st.characters(max_codepoint=127), min_size=1),  # ASCII characters only
+)
+def test_character_tokenizer_gives_same_cer_as_jiwer_for_ascii(
+    reference: str,
+    predicted: str,
+) -> None:
+    """Calculating error rate with character tokenizer gives same result as jiwer cer for ASCII strings.
+
+    Note, we cannot use Jiwer's tokenizer here, since it strips the input, which makes it so the tokens themselves
+    change if tokenized again. That is ``tokenize(tokenize(string)[i]) != tokenize(string)[i]``. This breaks an
+    assumption of the string confusion matrix.
+    """
+    # Jiwer strips strings before tokenizing, stringalign does not, so let's strip them first.
+    reference = reference.strip()
+    predicted = predicted.strip()
+    hypothesis.assume(reference)
+    cm = StringConfusionMatrix.from_strings(reference, predicted)
+    cer = cm.compute_token_error_rate()
+    assert jiwer.cer(reference, predicted) == pytest.approx(cer)
+
+
+@hypothesis.given(
+    predicted=st.text(alphabet=st.characters(max_codepoint=127)),  # ASCII characters only
+    reference=st.text(alphabet=st.characters(max_codepoint=127), min_size=1),  # ASCII characters only
+)
+def test_word_tokeniser_gives_same_wer_as_jiwer_for_simple_words(
+    reference: str,
+    predicted: str,
+) -> None:
+    """Calculating error rate with the jiwer word tokeniser gives the same result as jiwer wer for simple words."""
+    predicted = predicted.strip()
+    reference = reference.strip()
+    hypothesis.assume(reference)
+
+    def tokenizer(s: str) -> list[str]:
+        return jiwer.transformations.wer_default([s])[0]
+
+    assert len(tokenizer("ab cd")) == 2
+
+    cm = StringConfusionMatrix.from_strings(reference, predicted, tokenizer=tokenizer)  # type: ignore
+    wer = cm.compute_token_error_rate()
+    assert jiwer.wer(reference, predicted) == pytest.approx(wer)


### PR DESCRIPTION
The token error rate can be used to compute CER and WER